### PR TITLE
Implement user registration UI

### DIFF
--- a/codexmed/package-lock.json
+++ b/codexmed/package-lock.json
@@ -10,12 +10,16 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@hookform/resolvers": "^5.2.1",
         "@mui/icons-material": "^7.2.0",
         "@mui/material": "^7.2.0",
+        "@mui/x-date-pickers": "^8.9.0",
+        "date-fns": "^4.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.61.1",
-        "react-router-dom": "^7.7.1"
+        "react-router-dom": "^7.7.1",
+        "yup": "^1.6.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -1074,6 +1078,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+      "integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1406,6 +1422,94 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.9.0.tgz",
+      "integrity": "sha512-MD2/F63Tdsodygp3Z2VtfvvQhAiEVXvleuK9mqXuD6a1cCPOENICCJC98y2AKbOcsbVd37o6HCvWFOQsfsy7TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/utils": "^7.2.0",
+        "@mui/x-internals": "8.8.0",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.8.0.tgz",
+      "integrity": "sha512-qTRK5oINkAjZ7sIHpSnESLNq1xtQUmmfmGscYUSEP0uHoYh6pKkNWH9+7yzggRHuTv+4011VBwN9s+efrk+xZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/utils": "^7.2.0",
+        "reselect": "^5.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1742,6 +1846,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2420,6 +2530,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -3466,6 +3586,12 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3603,6 +3729,12 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -3816,6 +3948,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -3874,6 +4012,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -3898,6 +4042,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -4141,6 +4297,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
+      "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
       }
     }
   }

--- a/codexmed/package.json
+++ b/codexmed/package.json
@@ -12,12 +12,16 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@hookform/resolvers": "^5.2.1",
     "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
+    "@mui/x-date-pickers": "^8.9.0",
+    "date-fns": "^4.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.61.1",
-    "react-router-dom": "^7.7.1"
+    "react-router-dom": "^7.7.1",
+    "yup": "^1.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/codexmed/src/api/authService.ts
+++ b/codexmed/src/api/authService.ts
@@ -1,9 +1,38 @@
+export interface RegisterData {
+  fullName: string
+  email: string
+  password: string
+  phone: string
+  dni: string
+  birthdate: string
+  role: string
+  specialty?: string
+  clinic?: string
+  notifications?: boolean
+}
+
+export interface User {
+  id: string
+  role: string
+  name: string
+}
+
 export const loginRequest = async (_email: string, _password: string) => {
   // TODO: connect to API
+  void _email
+  void _password
   return { token: 'fake-token', role: 'admin' }
 }
 
-export const registerRequest = async (_email: string, _password: string) => {
-  // TODO: send registration data
-  return { success: true }
+export const register = async (data: RegisterData): Promise<User> => {
+  const users = JSON.parse(localStorage.getItem('users') || '[]') as RegisterData[]
+  if (users.some((u) => u.email === data.email)) {
+    throw new Error('Email ya registrado')
+  }
+
+  const user = { ...data, id: Date.now().toString() }
+  users.push(user)
+  localStorage.setItem('users', JSON.stringify(users))
+
+  return { id: user.id, role: data.role, name: data.fullName }
 }

--- a/codexmed/src/components/auth/RegisterForm.tsx
+++ b/codexmed/src/components/auth/RegisterForm.tsx
@@ -1,0 +1,212 @@
+import { useState } from 'react'
+import { useForm, Controller, type SubmitHandler, type Resolver } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
+import TextField from '@mui/material/TextField'
+import Button from '@mui/material/Button'
+import Alert from '@mui/material/Alert'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Checkbox from '@mui/material/Checkbox'
+import Stack from '@mui/material/Stack'
+import Link from '@mui/material/Link'
+import CircularProgress from '@mui/material/CircularProgress'
+import Typography from '@mui/material/Typography'
+import { Link as RouterLink, useNavigate } from 'react-router-dom'
+import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers'
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
+import PasswordField from './PasswordField'
+import GoogleButton from './GoogleButton'
+import RoleSelect from './RoleSelect'
+import { register as registerService } from '../../api/authService'
+
+interface FormData {
+  fullName: string
+  email: string
+  password: string
+  confirmPassword: string
+  phone: string
+  dni: string
+  birthdate: Date | null
+  role: string
+  specialty?: string
+  clinic?: string
+  terms: boolean
+  notifications: boolean
+}
+
+const schema = yup.object({
+  fullName: yup.string().required('Ingresa tu nombre completo'),
+  email: yup
+    .string()
+    .email('Email inválido')
+    .required('Ingresa tu email'),
+  password: yup
+    .string()
+    .min(6, 'Al menos 6 caracteres')
+    .required('Ingresa una contraseña'),
+  confirmPassword: yup
+    .string()
+    .oneOf([yup.ref('password')], 'Las contraseñas no coinciden')
+    .required('Confirma tu contraseña'),
+  phone: yup.string().required('Ingresa tu teléfono'),
+  dni: yup.string().required('Ingresa tu DNI'),
+  birthdate: yup.date().nullable().required('Ingresa tu fecha de nacimiento'),
+  role: yup.string().required('Selecciona un rol'),
+  specialty: yup.string().when('role', {
+    is: 'doctor',
+    then: (schema) => schema.required('Ingresa tu especialidad'),
+    otherwise: (schema) => schema.notRequired(),
+  }),
+  clinic: yup.string().notRequired(),
+  terms: yup
+    .boolean()
+    .oneOf([true], 'Debes aceptar los términos y condiciones'),
+  notifications: yup.boolean().notRequired(),
+})
+
+const RegisterForm = () => {
+  const navigate = useNavigate()
+  const [error, setError] = useState('')
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({
+    resolver: yupResolver(schema) as Resolver<FormData>,
+    defaultValues: { terms: false, notifications: false, birthdate: null },
+  })
+
+  const role = watch('role')
+
+  const onSubmit: SubmitHandler<FormData> = async (data) => {
+    setError('')
+    try {
+      const user = await registerService({
+        ...data,
+        birthdate: data.birthdate ? data.birthdate.toISOString() : '',
+      })
+      navigate(`/${user.role}/dashboard`)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Error al registrar'
+      setError(msg)
+    }
+  }
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <form onSubmit={handleSubmit(onSubmit)} noValidate>
+        <Stack spacing={2}>
+          {error && <Alert severity="error">{error}</Alert>}
+          <TextField
+            label="Nombre completo"
+            fullWidth
+            required
+            {...register('fullName')}
+            error={Boolean(errors.fullName)}
+            helperText={errors.fullName?.message}
+          />
+          <TextField
+            label="Email"
+            type="email"
+            fullWidth
+            required
+            {...register('email')}
+            error={Boolean(errors.email)}
+            helperText={errors.email?.message}
+          />
+          <PasswordField
+            label="Contraseña"
+            fullWidth
+            required
+            {...register('password')}
+            error={Boolean(errors.password)}
+            helperText={errors.password?.message}
+          />
+          <PasswordField
+            label="Confirmar contraseña"
+            fullWidth
+            required
+            {...register('confirmPassword')}
+            error={Boolean(errors.confirmPassword)}
+            helperText={errors.confirmPassword?.message}
+          />
+          <TextField
+            label="Teléfono"
+            fullWidth
+            required
+            {...register('phone')}
+            error={Boolean(errors.phone)}
+            helperText={errors.phone?.message}
+          />
+          <TextField
+            label="DNI"
+            fullWidth
+            required
+            {...register('dni')}
+            error={Boolean(errors.dni)}
+            helperText={errors.dni?.message}
+          />
+          <Controller
+            name="birthdate"
+            control={control}
+            render={({ field }) => (
+              <DatePicker
+                label="Fecha de nacimiento"
+                {...field}
+                onChange={(date) => field.onChange(date)}
+                slotProps={{ textField: { fullWidth: true, error: Boolean(errors.birthdate), helperText: errors.birthdate?.message } }}
+              />
+            )}
+          />
+          <RoleSelect
+            {...register('role')}
+            error={Boolean(errors.role)}
+            helperText={errors.role?.message}
+          />
+          {role === 'doctor' && (
+            <TextField
+              label="Especialidad"
+              fullWidth
+              required
+              {...register('specialty')}
+              error={Boolean(errors.specialty)}
+              helperText={errors.specialty?.message}
+            />
+          )}
+          <TextField
+            label="Centro médico / consultorio"
+            fullWidth
+            {...register('clinic')}
+            error={Boolean(errors.clinic)}
+            helperText={errors.clinic?.message}
+          />
+          <FormControlLabel
+            control={<Checkbox {...register('terms')} color="primary" />}
+            label="Acepto los términos y condiciones"
+          />
+          {errors.terms && (
+            <Typography color="error" variant="caption" sx={{ ml: 1 }}>
+              {errors.terms.message}
+            </Typography>
+          )}
+          <FormControlLabel
+            control={<Checkbox {...register('notifications')} color="primary" />}
+            label="Deseo recibir notificaciones"
+          />
+          <Button type="submit" variant="contained" fullWidth disabled={isSubmitting}>
+            {isSubmitting ? <CircularProgress size={24} /> : 'Registrarse'}
+          </Button>
+          <GoogleButton />
+          <Link component={RouterLink} to="/login" underline="hover" textAlign="center">
+            ¿Ya tienes cuenta? Iniciar sesión
+          </Link>
+        </Stack>
+      </form>
+    </LocalizationProvider>
+  )
+}
+
+export default RegisterForm

--- a/codexmed/src/components/auth/RoleSelect.tsx
+++ b/codexmed/src/components/auth/RoleSelect.tsx
@@ -1,0 +1,22 @@
+import TextField from '@mui/material/TextField'
+import MenuItem from '@mui/material/MenuItem'
+import type { TextFieldProps } from '@mui/material/TextField'
+
+const roles = [
+  { value: 'patient', label: 'Paciente' },
+  { value: 'doctor', label: 'Médico' },
+  { value: 'secretary', label: 'Secretaria' },
+  { value: 'admin', label: 'Admin' },
+]
+
+const RoleSelect = (props: TextFieldProps) => (
+  <TextField select fullWidth margin="normal" label="Rol" {...props}>
+    {roles.map((role) => (
+      <MenuItem key={role.value} value={role.value}>
+        {role.label}
+      </MenuItem>
+    ))}
+  </TextField>
+)
+
+export default RoleSelect

--- a/codexmed/src/pages/Register.tsx
+++ b/codexmed/src/pages/Register.tsx
@@ -1,46 +1,28 @@
 import Container from '@mui/material/Container'
-import TextField from '@mui/material/TextField'
-import Button from '@mui/material/Button'
-import Typography from '@mui/material/Typography'
 import Box from '@mui/material/Box'
-import { useState } from 'react'
-import { useAuth } from '../hooks/useAuth'
+import Navbar from '../components/common/Navbar'
+import AuthCard from '../components/auth/AuthCard'
+import RegisterForm from '../components/auth/RegisterForm'
 
 export default function Register() {
-  const { register } = useAuth()
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    register(email, password)
-  }
-
   return (
-    <Container maxWidth="xs">
-      <Box component="form" onSubmit={handleSubmit} sx={{ mt: 8 }}>
-        <Typography variant="h5" gutterBottom>Crear Cuenta</Typography>
-        <TextField
-          margin="normal"
-          required
-          fullWidth
-          label="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <TextField
-          margin="normal"
-          required
-          fullWidth
-          type="password"
-          label="Contraseña"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
-          Registrarse
-        </Button>
+    <Box sx={{ minHeight: '100vh', background: 'linear-gradient(#fff, #e3f2fd)' }}>
+      <Navbar auth />
+      <Container
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          py: 8,
+        }}
+      >
+        <AuthCard>
+          <RegisterForm />
+        </AuthCard>
+      </Container>
+      <Box sx={{ textAlign: 'center', pb: 2, color: 'text.secondary' }}>
+        © 2025 MEDM8
       </Box>
-    </Container>
+    </Box>
   )
 }


### PR DESCRIPTION
## Summary
- add registration page that mirrors login layout
- create comprehensive RegisterForm with role select and validation
- include reusable RoleSelect component
- implement simulated register service using localStorage
- install dependencies for forms and date pickers

## Testing
- `npm run lint` *(fails: some pre-existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688982686f4083219f05f3d83fc64f06